### PR TITLE
Add the ability to force the renewal of all certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ $ docker run -d \
     tutum/apache-php
 ```
 
+#### Force certificates renewal
+
+If needed, you can force a running letsencrypt-nginx-proxy-companion container to renew all certificates that are currently in use. Replace `nginx-letsencrypt` with the name of your `letsencrypt-nginx-proxy-companion` container in the following command:
+
+```bash
+$ docker exec nginx-letsencrypt /app/force_renew
+```
+
 #### Optional container environment variables
 
 Optional letsencrypt-nginx-proxy-companion container environment variables for custom configuration.

--- a/app/force_renew
+++ b/app/force_renew
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /app/letsencrypt_service --source-only
+
+update_certs --force-renew

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -135,6 +135,11 @@ update_certs() {
     [[ "$reload_nginx" == 'true' ]] && reload_nginx
 }
 
+# Allow the script functions to be sourced without starting the Service Loop.
+if [ "${1}" == "--source-only" ]; then
+  return 0
+fi
+
 pid=
 # Service Loop: When this script exits, start it again.
 trap '[[ $pid ]] && kill $pid; exec $0' EXIT

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -70,6 +70,7 @@ update_certs() {
         params_d_str=""
         [[ $DEBUG == true ]] && params_d_str+=" -v"
         [[ $REUSE_KEY == true ]] && params_d_str+=" --reuse_key"
+        [[ "${1}" == "--force-renew" ]] && params_d_str+=" --valid_min 7776000" && shift
 
         hosts_array_expanded=("${!hosts_array}")
         # First domain will be our base domain


### PR DESCRIPTION
This PR add a force_renew script in the /app folder.

The script force the renewal of all existing certificates via the --valid_min argument of simp_le (asking for a minimum validity of 90 days, which for LE certificates means they'll be renewed no matter what).